### PR TITLE
remove client_id for pb api 3.0.0 (no longer required)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Exclude unit test Runsettings 
+*.runsettings

--- a/Privatbank.Business.Tests/PrivatBankAutoClient.cs
+++ b/Privatbank.Business.Tests/PrivatBankAutoClient.cs
@@ -13,7 +13,6 @@ namespace Privatbank.Business.Tests
         public void SetUp()
         {
             _client = new PrivatbankAutoClient(
-                Environment.GetEnvironmentVariable("CLIENT_ID"),
                 Environment.GetEnvironmentVariable("CLIENT_TOKEN"));
         }
 
@@ -80,7 +79,7 @@ namespace Privatbank.Business.Tests
             Assert.NotNull(result);
         }
 
-        [Test]
+        /*[Test]
         public async Task TestCreatePayment()
         {
             var result = await _client.CreatePaymentAsync(new Payment
@@ -97,7 +96,7 @@ namespace Privatbank.Business.Tests
 
             Assert.NotNull(result.Reference);
             Assert.NotNull(result.PackedReference);
-        }
+    }*/
 
         [TearDown]
         public void TearDown()

--- a/Privatbank.Business.Tests/Privatbank.Business.Tests.csproj
+++ b/Privatbank.Business.Tests/Privatbank.Business.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Privatbank.Business.Tests/example env var.runsettings.example
+++ b/Privatbank.Business.Tests/example env var.runsettings.example
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+  <!-- configuration elements -->
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <!-- List of environment variables we want to set-->
+      <CLIENT_TOKEN>your_client_token</CLIENT_TOKEN>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/Privatbank.Business/Converters/StringDecimalConverter.cs
+++ b/Privatbank.Business/Converters/StringDecimalConverter.cs
@@ -7,9 +7,10 @@ namespace Privatbank.Business.Converters
 {
     internal class StringDecimalConverter : JsonConverter<decimal>
     {
+        static private NumberFormatInfo formatInfo = new NumberFormatInfo() { NumberDecimalSeparator = "." };
         public override decimal Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return decimal.Parse(reader.GetString());
+            return decimal.Parse(reader.GetString(), formatInfo);
         }
 
         public override void Write(Utf8JsonWriter writer, decimal value, JsonSerializerOptions options)

--- a/Privatbank.Business/PrivatbankAutoClient.cs
+++ b/Privatbank.Business/PrivatbankAutoClient.cs
@@ -12,7 +12,7 @@ using Privatbank.Business.Exceptions;
 namespace Privatbank.Business
 {
     /// <summary>
-    /// Privatbank API AutoClient. 
+    /// Privatbank API AutoClient. for api 3.0.0
     /// </summary>
     public class PrivatbankAutoClient : IDisposable
     {
@@ -23,23 +23,16 @@ namespace Privatbank.Business
         /// <summary>
         /// Initialize API AutoClient.
         /// </summary>
-        /// <param name="clientId">Client id.</param>
         /// <param name="clientToken">Client token.</param>
         /// <exception cref="ArgumentNullException">Mandatory parameter has not been provided.</exception>
-        public PrivatbankAutoClient(string clientId, string clientToken)
+        public PrivatbankAutoClient(string clientToken)
         {
-            if (string.IsNullOrEmpty(clientId))
-                throw new ArgumentNullException(nameof(clientId));
-
             if (string.IsNullOrEmpty(clientToken))
                 throw new ArgumentNullException(nameof(clientToken));
 
-            _httpClient = new HttpClient
-            {
+            _httpClient = new HttpClient {
                 BaseAddress = new Uri(ApiBaseAddress)
             };
-
-            _httpClient.DefaultRequestHeaders.Add("id", clientId);
             _httpClient.DefaultRequestHeaders.Add("token", clientToken);
         }
 


### PR DESCRIPTION
Removed client_id, it is no longer required by pb api
commented out TestCreatePayment
upgraded test project to net6.0
added number format for StringDecimalConverter to solve separator issue
added runsettings example file, runsettings files are excluded from git